### PR TITLE
feat(deno): Use owned values future

### DIFF
--- a/arrow-udf-js-deno-runtime/src/lib.rs
+++ b/arrow-udf-js-deno-runtime/src/lib.rs
@@ -213,16 +213,12 @@ pub fn create_runtime_snapshot() -> JsRuntimeForSnapshot {
         }
     }
 
-    let mut js_runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    JsRuntimeForSnapshot::new(RuntimeOptions {
         module_loader: Some(Rc::new(NoopModuleLoader)),
         extensions,
         inspector: false,
         ..Default::default()
-    });
-
-    bootstrap(&mut js_runtime, &options);
-
-    js_runtime
+    })
 }
 
 pub fn create_runtime(snapshot: &'static [u8]) -> deno_runtime::DenoRuntime {
@@ -280,13 +276,15 @@ pub fn create_runtime(snapshot: &'static [u8]) -> deno_runtime::DenoRuntime {
         runtime::init_ops(),
     ];
 
-    let runtime = JsRuntime::new(RuntimeOptions {
+    let mut runtime = JsRuntime::new(RuntimeOptions {
         module_loader: Some(Rc::new(NoopModuleLoader)),
         startup_snapshot: Some(snapshot),
         extensions,
         inspector: false,
         ..Default::default()
     });
+
+    bootstrap(&mut runtime, &options);
 
     deno_runtime::DenoRuntime::new(runtime)
 }

--- a/arrow-udf-js-deno/src/lib.rs
+++ b/arrow-udf-js-deno/src/lib.rs
@@ -66,6 +66,8 @@ pub struct InternalRuntime {
     big_decimal: ::v8::Global<::v8::Function>,
 }
 
+unsafe impl Send for InternalRuntime {}
+
 #[derive(Clone)]
 struct Function {
     mode: CallMode,

--- a/arrow-udf-js-deno/src/v8/mod.rs
+++ b/arrow-udf-js-deno/src/v8/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 use anyhow::Context;
 use std::sync::{
     atomic::{AtomicU64, Ordering},

--- a/arrow-udf-js-deno/src/values_future.rs
+++ b/arrow-udf-js-deno/src/values_future.rs
@@ -16,6 +16,7 @@ use std::{
     cell::RefCell,
     pin::Pin,
     rc::Rc,
+    sync::Arc,
     task::{Context, Poll},
 };
 


### PR DESCRIPTION
Removes the need of keeping a mutable hold when invoking call using the deno engine