### PR TITLE
fix(deno): downgrade deno-ast to v0.32

### DIFF
--- a/arrow-udf-js-deno-runtime/Cargo.toml
+++ b/arrow-udf-js-deno-runtime/Cargo.toml
@@ -14,7 +14,7 @@ with-dayjs = []
 
 [dependencies]
 anyhow = "1"
-deno_ast = { version = "1.0.1", features = ["cjs", "transpiling"] }
+deno_ast = { version = "0.32", features = ["cjs", "transpiling"] }
 deno_console = "0.144.0"
 deno_core = "0.272.0"
 deno_crypto = "0.158.0"


### PR DESCRIPTION
It seems that deno-ast v1.0 has been yanked for some reason. This PR downgrades its version to v0.32.

cc @bakjos