### PR TITLE
feat(arrow-udf-js-deno): Disable PKU

### DIFF
--- a/arrow-udf-js-deno-runtime/Cargo.toml
+++ b/arrow-udf-js-deno-runtime/Cargo.toml
@@ -16,7 +16,7 @@ with-dayjs = []
 anyhow = "1"
 deno_ast = { version = "0.34", features = ["cjs", "transpiling"] }
 deno_console = "0.144.0"
-deno_core = "0.272.0"
+deno_core = { version = "0.272.0", features = ["unsafe_use_unprotected_platform"] }
 deno_crypto = "0.158.0"
 deno_fetch = { version = "0.168.0", optional = true }
 deno_http = { version = "0.141.0", optional = true }


### PR DESCRIPTION
Due to V8's PKU feature, only the thread that initialized the V8 platform or those spawned from it can access the isolates; other threads will get a segmentation fault. Since the table function can be initialized from one thread and executed from a different one, this PR Disables PKU