### PR TITLE
chore: release arrow-udf-flight 0.2

### DIFF
--- a/arrow-udf-flight/CHANGELOG.md
+++ b/arrow-udf-flight/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-07-03
+
+### Changed
+
+- Update `arrow` version to >=52 and `tonic` to 0.11.
+
 ## [0.1.0] - 2024-05-07
 
 ### Added

--- a/arrow-udf-flight/Cargo.toml
+++ b/arrow-udf-flight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-flight"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Client for remote Arrow UDFs."
 repository = "https://github.com/risingwavelabs/arrow-udf"

--- a/arrow-udf-flight/README.md
+++ b/arrow-udf-flight/README.md
@@ -22,7 +22,7 @@ Add the following lines to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-arrow-udf-flight = "0.1"
+arrow-udf-flight = "0.2"
 ```
 
 ```rust,ignore

--- a/arrow-udf-js/Cargo.toml
+++ b/arrow-udf-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-js"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "JavaScript runtime for Arrow UDFs."
 repository = "https://github.com/risingwavelabs/arrow-udf"

--- a/arrow-udf-python/Cargo.toml
+++ b/arrow-udf-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-python"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Python runtime for Arrow UDFs."
 repository = "https://github.com/risingwavelabs/arrow-udf"


### PR DESCRIPTION
to be discussed: shall we hide tonic from public API so that we don't need to bump minor version if arrow or tonic bumps?