### PR TITLE
Fixed: wasm example bug

### DIFF
--- a/arrow-udf-wasm/examples/wasm.rs
+++ b/arrow-udf-wasm/examples/wasm.rs
@@ -38,7 +38,7 @@ fn main() {
     )
     .unwrap();
 
-    let output = runtime.call("gcd(int4,int4)->int4", &input).unwrap();
+    let output = runtime.call("gcd(int32,int32)->int32", &input).unwrap();
     print(&input, &output);
 
     println!("\ncall range");
@@ -50,7 +50,7 @@ fn main() {
     .unwrap();
 
     let iter = runtime
-        .call_table_function("range(int4)->>int4", &input)
+        .call_table_function("range(int32)->>int32", &input)
         .unwrap();
     for output in iter {
         let output = output.unwrap();


### PR DESCRIPTION
### Bug

wasm example call wrong function name. As shown below, the wasm file generated by [arrow-udf-example](https://github.com/risingwavelabs/arrow-udf/tree/main/arrow-udf-example) contains the function `gcd(int32,int32)->int32` and `range(int32)->>int32`, while wasm calls `gcd(int4,int4)->int4` and `range(int4)->>int4`

```
Runtime {
    config: Config {
        memory_size_limit: None,
        file_size_limit: None,
    },
    functions: {
        "decimal_add(decimal,decimal)->decimal",
        "oom()->null",
        "gcd(int32,int32)->int32",
        "create_file()->null",
        "sleep(int32)->int32",
        "segfault()->null",
        "datetime(date32,time64)->timestamp",
        "length(string)->int32",
        "range(int32)->>int32",
        "jsonb_access(json,int32)->json",
        "div(int32,int32)->int32",
        "length(binary)->int32",
        "key_value(string)->struct KeyValue",
    },
    types: {
        "KeyValue": "key:string,value:string",
    },
    instances: 0,
}
```

### OS
Apple M1