### PR TITLE
fix: allow writer-style return value for `largestring`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           cd arrow-udf-flight/java
           _JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED" mvn exec:java &
           pid=$!
-          sleep 5
+          sleep 10
           cargo test -p arrow-udf-flight
           kill $pid
           cd ../..

--- a/arrow-udf-js-deno/tests/js.rs
+++ b/arrow-udf-js-deno/tests/js.rs
@@ -718,11 +718,7 @@ async fn test_interval() {
 
     /// Generate a record batch with a single column of type `List<T>`.
     fn interval_input(unit: arrow_schema::IntervalUnit) -> RecordBatch {
-        let schema = Schema::new(vec![Field::new(
-            "x",
-            DataType::Interval(unit.clone()),
-            true,
-        )]);
+        let schema = Schema::new(vec![Field::new("x", DataType::Interval(unit), true)]);
 
         match unit {
             arrow_schema::IntervalUnit::YearMonth => {
@@ -781,11 +777,7 @@ async fn test_interval_identity() {
 
     /// Generate a record batch with a single column of type `List<T>`.
     fn interval_input(unit: arrow_schema::IntervalUnit) -> RecordBatch {
-        let schema = Schema::new(vec![Field::new(
-            "x",
-            DataType::Interval(unit.clone()),
-            true,
-        )]);
+        let schema = Schema::new(vec![Field::new("x", DataType::Interval(unit), true)]);
 
         match unit {
             arrow_schema::IntervalUnit::YearMonth => {
@@ -831,7 +823,7 @@ async fn test_interval_identity() {
         runtime
             .add_function(
                 "interval_type",
-                DataType::Interval(unit.clone()),
+                DataType::Interval(unit),
                 CallMode::ReturnNullOnNullInput,
                 r#"
                 export function interval_type(a) {

--- a/arrow-udf-macros/src/gen.rs
+++ b/arrow-udf-macros/src/gen.rs
@@ -330,10 +330,13 @@ impl FunctionAttr {
             let builder = builder(&self.ret);
             // append the `output` to the `builder`
             let append_output = if user_fn.write {
-                if self.ret != "string" && self.ret != "binary" {
+                if !matches!(
+                    self.ret.as_str(),
+                    "string" | "binary" | "largestring" | "largebinary"
+                ) {
                     return Err(Error::new(
                         Span::call_site(),
-                        "`&mut Write` can only be used for functions that return `string` or `binary`",
+                        "`&mut Write` can only be used for functions that return `string`, `binary`, `largestring`, or `largebinary`",
                     ));
                 }
                 quote! {{

--- a/arrow-udf/CHANGELOG.md
+++ b/arrow-udf/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix deprecated warnings with `arrow` v52.
+- Allow writer-style return value for `largestring`. 
 
 ## [0.3.0] - 2024-04-25
 

--- a/arrow-udf/tests/tests.rs
+++ b/arrow-udf/tests/tests.rs
@@ -137,21 +137,25 @@ fn substring_binary(s: &[u8], start: i32) -> &[u8] {
 }
 
 #[function("to_string1(int) -> string")]
+#[function("to_string1(int) -> largestring")]
 fn to_string1(x: i32) -> String {
     x.to_string()
 }
 
 #[function("to_string2(int) -> string")]
+#[function("to_string2(int) -> largestring")]
 fn to_string2(x: i32) -> Box<str> {
     x.to_string().into()
 }
 
 #[function("to_string3(int) -> string")]
+#[function("to_string3(int) -> largestring")]
 fn to_string3(x: i32, output: &mut impl std::fmt::Write) {
     write!(output, "{}", x).unwrap();
 }
 
 #[function("to_string4(int) -> string")]
+#[function("to_string4(int) -> largestring")]
 fn to_string4(x: i32, output: &mut impl std::fmt::Write) -> Option<()> {
     let x = usize::try_from(x).ok()?;
     write!(output, "{}", x).unwrap();
@@ -159,22 +163,26 @@ fn to_string4(x: i32, output: &mut impl std::fmt::Write) -> Option<()> {
 }
 
 #[function("bytes1(int) -> binary")]
+#[function("bytes1(int) -> largebinary")]
 fn bytes1(x: i32) -> Vec<u8> {
     vec![0; x as usize]
 }
 
 #[function("bytes2(int) -> binary")]
+#[function("bytes2(int) -> largebinary")]
 fn bytes2(x: i32) -> Box<[u8]> {
     vec![0; x as usize].into()
 }
 
 #[function("bytes3(int) -> binary")]
+#[function("bytes3(int) -> largebinary")]
 fn bytes3(x: i32) -> [u8; 10] {
     [x as u8; 10]
 }
 
 // FIXME: std::io::Write is not supported yet
 // #[function("bytes4(int) -> binary")]
+// #[function("bytes4(int) -> largebinary")]
 // fn bytes4(x: i32, output: &mut impl std::io::Write) {
 //     for _ in 0..x {
 //         output.write_all(&[0]).unwrap();


### PR DESCRIPTION
Writer-style return value was only supported for `string` but not `largestring`.