### PR TITLE
doc: refine doc to highlight arrow-udf's difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ The functions can be executed natively, or in WebAssembly, or in a [remote serve
 [arrow-udf-flight/python]: ./arrow-udf-flight/python
 [arrow-udf-flight/java]: ./arrow-udf-flight/java
 
+> [!NOTE]
+> [arrow-udf] generates `RecordBatch` Rust functions from scalar functions, and can be used in more general contexts 
+> whenever you need to work with Arrow Data in Rust, not specifically user-provided code.
+>
+> Other crates are more focused on providing runtimes or protocols for running user-provided code.
+
+- `arrow-udf`: You call `fn(&RecordBatch)->RecordBatch` directly, as if you wrote it by hand.
+- `arrow-udf-python/js/wasm`: You first `add_function` to a `Runtime`, and then call it with the `Runtime`.
+- `arrow-udf-flight`: You start a `Client` to call the function running in a remote `Server` process.
+
 ## Extension Types
 
 In addition to the standard types defined by Arrow, these crates also support the following data types through Arrow's [extension type](https://arrow.apache.org/docs/format/Columnar.html#format-metadata-extension-types). When using extension types, you need to add the `ARROW:extension:name` key to the field's metadata.

--- a/arrow-udf-macros/README.md
+++ b/arrow-udf-macros/README.md
@@ -1,0 +1,1 @@
+This crate implements the `#[function]` macro for the `arrow-udf` crate.

--- a/arrow-udf-wasm/README.md
+++ b/arrow-udf-wasm/README.md
@@ -63,7 +63,7 @@ let input: RecordBatch = ...;
 let output = runtime.call("gcd(int4,int4)->int4", &input).unwrap();
 ```
 
-The WebAssembly runtime is powered by [wasmtime](https://wasmtime.dev/). 
+The WebAssembly runtime is powered by [Wasmtime](https://wasmtime.dev/). 
 Notice that each WebAssembly instance can only run single-threaded, we maintain an instance pool internally to support parallel calls from multiple threads.
 
 See the [example](./examples/wasm.rs) for more details. To run the example:

--- a/arrow-udf/README.md
+++ b/arrow-udf/README.md
@@ -125,3 +125,5 @@ let output = sig.function.as_scalar().unwrap()(&input).unwrap();
 ```
 
 See the [example](https://github.com/risingwavelabs/arrow-udf/blob/main/arrow-udf/examples/rust.rs) and the [documentation for the #[function] macro](https://docs.rs/arrow-udf/latest/arrow_udf/attr.function.html) for more details.
+
+See also the blog post: [Simplifying SQL Function Implementation with Rust Procedural Macro](https://risingwave.com/blog/simplifying-sql-function-implementation-with-rust-procedural-macro/).

--- a/arrow-udf/README.md
+++ b/arrow-udf/README.md
@@ -3,6 +3,8 @@
 [![Crate](https://img.shields.io/crates/v/arrow-udf.svg)](https://crates.io/crates/arrow-udf)
 [![Docs](https://docs.rs/arrow-udf/badge.svg)](https://docs.rs/arrow-udf)
 
+Generate `RecordBatch` functions from scalar functions painlessly with the [#[function] macro](https://docs.rs/arrow-udf/latest/arrow_udf/attr.function.html).
+
 ## Usage
 
 Add the following lines to your `Cargo.toml`:
@@ -26,8 +28,7 @@ fn gcd(mut a: i32, mut b: i32) -> i32 {
 }
 ```
 
-The macro will generate a function that takes a `RecordBatch` as input and returns a `RecordBatch` as output.
-The function can be named with the optional `output` parameter.
+The generated function can be named with the optional `output` parameter.
 If not specified, it will be named arbitrarily like `gcd_int32_int32_int32_eval`.
 
 You can then call the generated function on a `RecordBatch`:
@@ -123,4 +124,4 @@ let sig = REGISTRY.get("gcd", &[int32.clone(), int32.clone()], &int32).expect("g
 let output = sig.function.as_scalar().unwrap()(&input).unwrap();
 ```
 
-See the [example](./examples/rust.rs) for more details.
+See the [example](https://github.com/risingwavelabs/arrow-udf/blob/main/arrow-udf/examples/rust.rs) and the [documentation for the #[function] macro](https://docs.rs/arrow-udf/latest/arrow_udf/attr.function.html) for more details.


### PR DESCRIPTION
I'm inspired by https://github.com/apache/datafusion/issues/11413. It seems they just need the function macro, not like "UDF", which surprised me a little.