### PR TITLE
chore: bump arrow-udf and arrow-udf-runtime to v0.9.0

### DIFF
--- a/arrow-udf-runtime/CHANGELOG.md
+++ b/arrow-udf-runtime/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.9.0] - 2026-04-22
+
+### Changed
+
+- Update `arrow` version from `54` to `58`.
+- Update `wasmtime` and `wasi-common` version from `27` to `36`.
+- Update `tonic` version from `0.12` to `0.14`.
+
 ## [0.8.0] - 2025-04-10
 
 ### Changed

--- a/arrow-udf-runtime/Cargo.toml
+++ b/arrow-udf-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-runtime"
-version = "0.8.0"
+version = "0.9.0"
 description = "Runtime for Arrow UDFs."
 keywords = ["arrow", "udf", "runtime"]
 edition.workspace = true

--- a/arrow-udf/CHANGELOG.md
+++ b/arrow-udf/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-22
+
+### Changed
+
+- Update `arrow` version from `56` to `58`.
+- Update `duckdb` version from `=1.4` to `=1.10502`.
+
+### Breaking Changes
+
+- The `duckdb` feature no longer enables `loadable-extension` on `duckdb-rs`. Users building a DuckDB loadable extension should enable it explicitly on their own `duckdb` dependency.
+
 ## [0.8.0] - 2026-01-14
 
 ### Changed

--- a/arrow-udf/Cargo.toml
+++ b/arrow-udf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf"
-version = "0.8.0"
+version = "0.9.0"
 description = "User-defined function framework for arrow-rs."
 keywords = ["arrow", "udf"]
 categories = ["wasm"]
@@ -16,7 +16,7 @@ arrow-arith.workspace = true
 arrow-array.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
-arrow-udf-macros = { version = "=0.8.0", path = "arrow-udf-macros" }
+arrow-udf-macros = { version = "=0.9.0", path = "arrow-udf-macros" }
 chrono = { version = "0.4", default-features = false }
 genawaiter2 = "0.100.1"
 linkme = { version = "0.3", optional = true }

--- a/arrow-udf/arrow-udf-macros/Cargo.toml
+++ b/arrow-udf/arrow-udf-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-udf-macros"
-version = "0.8.0"
+version = "0.9.0"
 description = "Procedural macros for generating Arrow functions."
 keywords = ["arrow", "udf"]
 edition.workspace = true


### PR DESCRIPTION
## Summary

Prepare a 0.9.0 release for both publishable crates.

### arrow-udf 0.8.0 → 0.9.0

- Update `arrow` from `56` to `58`.
- Update `duckdb` from `=1.4` to `=1.10502`.
- **Breaking:** The `duckdb` feature no longer enables `loadable-extension` on `duckdb-rs`. Users building a DuckDB loadable extension should enable it explicitly on their own `duckdb` dependency.

### arrow-udf-runtime 0.8.0 → 0.9.0

- Update `arrow` from `54` to `58`.
- Update `wasmtime` and `wasi-common` from `27` to `36`.
- Update `tonic` from `0.12` to `0.14`.

`arrow-udf-macros` is bumped to `0.9.0` in lock step (pinned via `=0.9.0` by `arrow-udf`).

## Test plan

- [x] `cargo check -p arrow-udf -p arrow-udf-macros`
- [x] `cargo check -p arrow-udf-runtime --no-default-features --features "wasm,javascript,remote"`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)